### PR TITLE
Potential fix for code scanning alert no. 11: Open URL redirect

### DIFF
--- a/server/internal/http/handleAuth.go
+++ b/server/internal/http/handleAuth.go
@@ -342,5 +342,10 @@ func (s *HttpServer) createFinalSessionAndRedirect(w http.ResponseWriter, r *htt
 	if c, err := r.Cookie("pending_next"); err == nil {
 		next = c.Value
 	}
+	// Validate that the next URL is local
+	next = strings.ReplaceAll(next, "\\", "/") // Normalize backslashes
+	if parsedURL, err := url.Parse(next); err != nil || parsedURL.Hostname() != "" {
+		next = "/"
+	}
 	http.Redirect(w, r, next, http.StatusSeeOther)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/aaronlmathis/gosight/security/code-scanning/11](https://github.com/aaronlmathis/gosight/security/code-scanning/11)

To fix the issue, we need to validate the `next` variable to ensure it is a local URL before using it in the `http.Redirect` function. This can be achieved by parsing the URL and checking that its hostname is empty, which indicates it is a relative URL. Additionally, we should sanitize the input by replacing backslashes with forward slashes to prevent browser-specific quirks.

Steps to fix:
1. Parse the `next` URL using `url.Parse`.
2. Check that the `Hostname()` of the parsed URL is empty.
3. If the validation fails, default to a safe local path (e.g., `/`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
