### PR TITLE
New logstore option - VictoriaMetrics

### DIFF
--- a/agent/internal/logs/logrunner/runner.go
+++ b/agent/internal/logs/logrunner/runner.go
@@ -106,12 +106,16 @@ func (r *LogRunner) Run(ctx context.Context) {
 				continue
 			}
 
+			// set job tag for victoriametrics.
+			r.Meta.Tags["job"] = "gosight-logs"
+
 			// clone base meta before modifying it
 			meta := meta.CloneMetaWithTags(r.Meta, nil)
 
 			// Generate Endpoint ID
 			endpointID := utils.GenerateEndpointID(meta)
 			meta.EndpointID = endpointID
+			meta.Tags["instance"] = meta.Hostname
 
 			//utils.Debug("Processing %d log batches for sending.", len(logBatches))
 

--- a/agent/internal/logs/logsender/sender.go
+++ b/agent/internal/logs/logsender/sender.go
@@ -62,7 +62,7 @@ func (s *LogSender) Close() error {
 
 func (s *LogSender) SendLogs(payload *model.LogPayload) error {
 	pbLogs := make([]*proto.LogEntry, 0, len(payload.Logs))
-
+	utils.Debug("Log Meta: %v", payload.Meta)
 	for _, log := range payload.Logs {
 		pbLog := &proto.LogEntry{
 			Timestamp: timestamppb.New(log.Timestamp),
@@ -129,7 +129,7 @@ func (s *LogSender) SendLogs(payload *model.LogPayload) error {
 		return err
 	}
 
-	//utils.Debug("Streamed %d logs", len(pbLogs))
+	utils.Debug("Streamed %d logs", len(pbLogs))
 	return nil
 }
 func (s *LogSender) reconnectStream(ctx context.Context) error {

--- a/server/internal/bootstrap/caches.go
+++ b/server/internal/bootstrap/caches.go
@@ -56,7 +56,10 @@ func InitCaches(ctx context.Context, dataStore datastore.DataStore) (*cache.Cach
 	processCache := cache.NewProcessCache()
 	caches.Processes = processCache
 
-	// Initialize other caches as needed...
+	// Log Cache
+
+	logCache := cache.NewLogCache()
+	caches.Logs = logCache
 
 	return caches, nil
 }

--- a/server/internal/bootstrap/init.go
+++ b/server/internal/bootstrap/init.go
@@ -67,10 +67,6 @@ func InitGoSight(ctx context.Context) (*sys.SystemContext, error) {
 	metricIndex, err := InitMetricIndex()
 	utils.Must("Metric index", err)
 
-	// Initialize log store
-	logStore, err := InitLogStore(ctx, cfg)
-	utils.Must("Log store", err)
-
 	// Initialize data store
 	dataStore, err := InitDataStore(cfg)
 	utils.Must("Data store", err)
@@ -128,6 +124,10 @@ func InitGoSight(ctx context.Context) (*sys.SystemContext, error) {
 	// Init metric store
 	metricStore, err := InitMetricStore(ctx, cfg, caches.Metrics)
 	utils.Must("Metric store", err)
+
+	// Initialize log store
+	logStore, err := InitLogStore(ctx, cfg, caches.Logs)
+	utils.Must("Log store", err)
 
 	// Initialize SyncManager (synchronization of caches with datastore)
 	syncManager := syncmanager.NewSyncManager(ctx, caches, dataStore, tracker, cfg.Server.SyncInterval)

--- a/server/internal/bootstrap/log_store.go
+++ b/server/internal/bootstrap/log_store.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aaronlmathis/gosight/server/internal/cache"
 	"github.com/aaronlmathis/gosight/server/internal/config"
 	"github.com/aaronlmathis/gosight/server/internal/store/logstore"
 	"github.com/aaronlmathis/gosight/shared/utils"
@@ -33,11 +34,11 @@ import (
 
 // InitLogStore initializes the log store for the GoSight agent.
 // The log store is responsible for storing and retrieving logs.
-func InitLogStore(ctx context.Context, cfg *config.Config) (logstore.LogStore, error) {
+func InitLogStore(ctx context.Context, cfg *config.Config, logCache cache.LogCache) (logstore.LogStore, error) {
 	engine := cfg.LogStore.Engine
 	utils.Info("Initializing log store engine: %s", engine)
 
-	s, err := logstore.InitLogStore(ctx, cfg)
+	s, err := logstore.InitLogStore(ctx, cfg, logCache)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init log store: %w", err)
 	}

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -85,6 +85,7 @@ type Config struct {
 	LogStore struct {
 		Engine        string `yaml:"engine"` // file, victoriametric etc
 		Dir           string `yaml:"dir"`
+		Url           string `yaml:"url,omitempty"` // optional URL for remote storage
 		Workers       int    `yaml:"workers"`
 		QueueSize     int    `yaml:"queue_size"`
 		BatchSize     int    `yaml:"batch_size"`

--- a/server/internal/http/handleLogAPI.go
+++ b/server/internal/http/handleLogAPI.go
@@ -147,7 +147,6 @@ func parseLogFilterFromQuery(r *http.Request) model.LogFilter {
 		}
 		return t
 	}
-
 	parseInt := func(key string, def int) int {
 		val := q.Get(key)
 		if val == "" {
@@ -200,16 +199,6 @@ func parseLogFilterFromQuery(r *http.Request) model.LogFilter {
 	return filter
 }
 
-func parseTime(s string) time.Time {
-	if s == "" {
-		return time.Time{}
-	}
-	t, err := time.Parse("2006-01-02T15:04:05", s)
-	if err != nil {
-		return time.Time{}
-	}
-	return t
-}
 
 // matchesSearch checks if a log entry matches the search keyword.
 // It checks if the keyword is present in the message, source, category,

--- a/server/internal/store/logstore/filestore.go/filestore.go
+++ b/server/internal/store/logstore/filestore.go/filestore.go
@@ -89,13 +89,3 @@ func (f *FileStore) Close() error {
 	// No-op for file store currently
 	return nil
 }
-
-// HELPERS
-
-func totalLogCount(payloads []model.LogPayload) int {
-	count := 0
-	for _, p := range payloads {
-		count += len(p.Logs)
-	}
-	return count
-}

--- a/server/internal/store/logstore/registery.go
+++ b/server/internal/store/logstore/registery.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aaronlmathis/gosight/server/internal/cache"
 	"github.com/aaronlmathis/gosight/server/internal/config"
 	"github.com/aaronlmathis/gosight/server/internal/store/logstore/filestore.go"
+	victorialogstore "github.com/aaronlmathis/gosight/server/internal/store/logstore/victoriametrics"
 
 	"github.com/aaronlmathis/gosight/shared/utils"
 )
 
-func InitLogStore(ctx context.Context, cfg *config.Config) (LogStore, error) {
+func InitLogStore(ctx context.Context, cfg *config.Config, logCache cache.LogCache) (LogStore, error) {
 	engine := cfg.LogStore.Engine
 	if engine == "" {
 		engine = "file"
@@ -18,9 +20,17 @@ func InitLogStore(ctx context.Context, cfg *config.Config) (LogStore, error) {
 	utils.Debug("InitLogStore selected engine: %s", engine)
 	switch engine {
 	case "file":
-		utils.Debug("Bootstrapping JSON File Store.")
+		utils.Debug("Bootstrapping JSON File LogStore.")
 		s := filestore.New(cfg.LogStore.Dir)
 		utils.Debug("Returning JSON Filestore at: %p", s)
+		return s, nil
+	case "victoriametrics":
+		utils.Debug("Bootstrapping VictoriaMetrics LogStore.")
+		s, err := victorialogstore.NewVictoriaLogStore(cfg.LogStore.Url, cfg.LogStore.Dir, logCache)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create VictoriaMetrics LogStore: %w", err)
+		}
+		utils.Debug("Returning VictoriaMetric LogStore at: %p", s)
 		return s, nil
 	default:
 		return nil, fmt.Errorf("unsupported storage engine: %s", engine)

--- a/server/internal/store/logstore/victoriametrics/disk.go
+++ b/server/internal/store/logstore/victoriametrics/disk.go
@@ -1,0 +1,127 @@
+/*
+SPDX-License-Identifier: GPL-3.0-or-later
+
+Copyright (C) 2025 Aaron Mathis aaron.mathis@gmail.com
+
+This file is part of GoSight.
+
+GoSight is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+GoSight is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GoBright. If not, see https://www.gnu.org/licenses/.
+*/
+
+// server/internal/store/logstore/victoriametrics/disk.go
+
+package victorialogstore
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/aaronlmathis/gosight/shared/model"
+)
+
+func (v *VictoriaLogStore) writeCompressedJSONToDisk(batch []model.LogPayload) error {
+	for _, payload := range batch {
+		if len(payload.Logs) == 0 {
+			continue
+		}
+
+		t := payload.Timestamp
+		if t.IsZero() && len(payload.Logs) > 0 {
+			t = payload.Logs[0].Timestamp
+		}
+		if t.IsZero() {
+			t = time.Now()
+		}
+
+		dir := filepath.Join(v.logsPath, "logs", t.Format("2006"), t.Format("01"), t.Format("02"))
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("create dir: %w", err)
+		}
+
+		hour := t.Format("15")
+		filename := fmt.Sprintf("%s_%s.json.gz", payload.EndpointID, hour)
+		fullPath := filepath.Join(dir, filename)
+
+		f, err := os.OpenFile(fullPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			return fmt.Errorf("open file: %w", err)
+		}
+		defer f.Close()
+
+		gz := gzip.NewWriter(f)
+		defer gz.Close()
+
+		var wrapped []model.StoredLog
+		for _, log := range payload.Logs {
+			logID := hash(log.Timestamp.String() + log.Message)
+			wrapped = append(wrapped, model.StoredLog{
+				LogID: logID,
+				Log:   log,
+			})
+		}
+
+		if err := json.NewEncoder(gz).Encode(wrapped); err != nil {
+			return fmt.Errorf("write logs: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (v *VictoriaLogStore) writeCompressedWrappedLogs(logs []model.StoredLog) error {
+	if len(logs) == 0 {
+		return nil
+	}
+
+	// Use first timestamp to determine file path
+	t := logs[0].Log.Timestamp
+	if t.IsZero() {
+		t = time.Now()
+	}
+
+	dir := filepath.Join(v.logsPath, "logs", t.Format("2006"), t.Format("01"), t.Format("02"))
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+
+	hour := t.Format("15")
+	endpointID := logs[0].Meta.EndpointID
+	if endpointID == "" {
+		endpointID = "unknown"
+	}
+	filename := fmt.Sprintf("%s_%s.json.gz", endpointID, hour)
+	fullPath := filepath.Join(dir, filename)
+
+	f, err := os.OpenFile(fullPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return fmt.Errorf("open file: %w", err)
+	}
+	defer f.Close()
+
+	gz := gzip.NewWriter(f)
+	defer gz.Close()
+
+	enc := json.NewEncoder(gz)
+	for _, entry := range logs {
+		if err := enc.Encode(entry); err != nil {
+			return fmt.Errorf("write log: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/server/internal/store/logstore/victoriametrics/helpers.go
+++ b/server/internal/store/logstore/victoriametrics/helpers.go
@@ -1,0 +1,264 @@
+/*
+SPDX-License-Identifier: GPL-3.0-or-later
+
+Copyright (C) 2025 Aaron Mathis aaron.mathis@gmail.com
+
+This file is part of GoSight.
+
+GoSight is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+GoSight is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GoBright. If not, see https://www.gnu.org/licenses/.
+*/
+
+// server/internal/store/victoriametrics.go
+
+package victoriametricstore
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aaronlmathis/gosight/shared/model"
+)
+
+// buildPrometheusFormat converts a batch of MetricPayloads into a Prometheus-compatible string format.
+// Each metric is formatted with its name, labels, value, and timestamp.
+func buildPrometheusFormat(batch []model.MetricPayload) string {
+	var sb strings.Builder
+
+	for _, payload := range batch {
+		ts := payload.Timestamp.UnixNano() / 1e6
+
+		// Core labels from Meta + Tags
+		baseLabels := BuildPromLabels(payload.Meta)
+
+		for _, m := range payload.Metrics {
+			fullName := normalizeMetricName(m.Name)
+
+			// Start with base Meta + Tags
+			labels := make(map[string]string, len(baseLabels)+len(m.Dimensions))
+			for k, v := range baseLabels {
+				labels[k] = v
+			}
+
+			// Apply metric-specific dimensions (override any key)
+			for k, v := range m.Dimensions {
+				labels[k] = v
+			}
+
+			sb.WriteString(fmt.Sprintf("%s{%s} %f %d\n",
+				fullName,
+				formatLabelMap(labels),
+				m.Value,
+				ts,
+			))
+		}
+	}
+
+	return sb.String()
+}
+
+// normalizeMetricName normalizes the metric name for Prometheus compatibility.
+func normalizeMetricName(name string) string {
+	return strings.ToLower(strings.ReplaceAll(name, "/", "."))
+}
+
+// formatLabelMap prepares potential labels for Prometheus scraping.
+// It combines payload.Meta tags and metric dimensions into a single map.
+// It converts the labels map to a string in the format: key1="value1",key2="value2",...
+// It allows Dimensions to override Meta tags if two keys are the same.
+
+func formatLabelMap(labels map[string]string) string {
+	var parts []string
+	for k, v := range labels {
+		parts = append(parts, fmt.Sprintf(`%s="%s"`, k, v))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}
+
+// BuildPromLabels constructs Prometheus-compatible labels from the given Meta object.
+// It filters out any labels that are already present in the Meta object to avoid duplication.
+// The resulting labels are returned as a map of key-value pairs.
+
+func BuildPromLabels(meta *model.Meta) map[string]string {
+	if meta == nil {
+		return map[string]string{}
+	}
+
+	labels := map[string]string{}
+
+	// Identity and system labels from Meta
+	if meta.AgentID != "" {
+		labels["agent_id"] = meta.AgentID
+	}
+	if meta.AgentVersion != "" {
+		labels["agent_version"] = meta.AgentVersion
+	}
+	if meta.HostID != "" {
+		labels["host_id"] = meta.HostID
+	}
+	if meta.EndpointID != "" {
+		labels["endpoint_id"] = meta.EndpointID
+	}
+	if meta.Hostname != "" {
+		labels["hostname"] = meta.Hostname
+	}
+	if meta.IPAddress != "" {
+		labels["ip_address"] = meta.IPAddress
+	}
+	if meta.OS != "" {
+		labels["os"] = meta.OS
+	}
+	if meta.OSVersion != "" {
+		labels["os_version"] = meta.OSVersion
+	}
+	if meta.Platform != "" {
+		labels["platform"] = meta.Platform
+	}
+	if meta.PlatformFamily != "" {
+		labels["platform_family"] = meta.PlatformFamily
+	}
+	if meta.PlatformVersion != "" {
+		labels["platform_version"] = meta.PlatformVersion
+	}
+	if meta.KernelArchitecture != "" {
+		labels["kernel_architecture"] = meta.KernelArchitecture
+	}
+	if meta.KernelVersion != "" {
+		labels["kernel_version"] = meta.KernelVersion
+	}
+	if meta.VirtualizationSystem != "" {
+		labels["virtualization_system"] = meta.VirtualizationSystem
+	}
+	if meta.VirtualizationRole != "" {
+		labels["virtualization_role"] = meta.VirtualizationRole
+	}
+	if meta.Architecture != "" {
+		labels["architecture"] = meta.Architecture
+	}
+	if meta.Environment != "" {
+		labels["environment"] = meta.Environment
+	}
+	if meta.Region != "" {
+		labels["region"] = meta.Region
+	}
+	if meta.AvailabilityZone != "" {
+		labels["availability_zone"] = meta.AvailabilityZone
+	}
+	if meta.InstanceID != "" {
+		labels["instance_id"] = meta.InstanceID
+	}
+	if meta.InstanceType != "" {
+		labels["instance_type"] = meta.InstanceType
+	}
+	if meta.AccountID != "" {
+		labels["account_id"] = meta.AccountID
+	}
+	if meta.ProjectID != "" {
+		labels["project_id"] = meta.ProjectID
+	}
+	if meta.ResourceGroup != "" {
+		labels["resource_group"] = meta.ResourceGroup
+	}
+	if meta.VPCID != "" {
+		labels["vpc_id"] = meta.VPCID
+	}
+	if meta.SubnetID != "" {
+		labels["subnet_id"] = meta.SubnetID
+	}
+	if meta.ImageID != "" {
+		labels["image_id"] = meta.ImageID
+	}
+	if meta.ServiceID != "" {
+		labels["service_id"] = meta.ServiceID
+	}
+	if meta.ContainerID != "" {
+		labels["container_id"] = meta.ContainerID
+	}
+	if meta.ContainerName != "" {
+		labels["container_name"] = meta.ContainerName
+	}
+	if meta.PodName != "" {
+		labels["pod_name"] = meta.PodName
+	}
+	if meta.ClusterName != "" {
+		labels["cluster_name"] = meta.ClusterName
+	}
+	if meta.NodeName != "" {
+		labels["node_name"] = meta.NodeName
+	}
+	if meta.ContainerImageID != "" {
+		labels["container_image_id"] = meta.ContainerImageID
+	}
+	if meta.ContainerImageName != "" {
+		labels["container_image_name"] = meta.ContainerImageName
+	}
+
+	if meta.Application != "" {
+		labels["application"] = meta.Application
+	}
+	if meta.Service != "" {
+		labels["service"] = meta.Service
+	}
+	if meta.Version != "" {
+		labels["version"] = meta.Version
+	}
+	if meta.DeploymentID != "" {
+		labels["deployment_id"] = meta.DeploymentID
+	}
+	if meta.PublicIP != "" {
+		labels["public_ip"] = meta.PublicIP
+	}
+	if meta.PrivateIP != "" {
+		labels["private_ip"] = meta.PrivateIP
+	}
+	if meta.MACAddress != "" {
+		labels["mac_address"] = meta.MACAddress
+	}
+	if meta.NetworkInterface != "" {
+		labels["network_interface"] = meta.NetworkInterface
+	}
+
+	// Tags (pre-filtered to avoid duplication)
+	for k, v := range meta.Tags {
+		if _, exists := labels[k]; !exists {
+			labels[k] = v
+		}
+	}
+
+	return labels
+}
+
+// BuildPromQL constructs a Prometheus Query Language (PromQL) query string
+func BuildPromQL(metric string, filters map[string]string) string {
+	if len(filters) == 0 {
+		return metric
+	}
+	var parts []string
+	for k, v := range filters {
+		parts = append(parts, fmt.Sprintf(`%s="%s"`, k, v))
+	}
+	sort.Strings(parts)
+	return fmt.Sprintf(`%s{%s}`, metric, strings.Join(parts, ","))
+}
+
+// parseDurationToSeconds converts a duration string (e.g., "5s", "1m", "2h") to seconds.
+func parseDurationToSeconds(step string) (int, error) {
+	d, err := time.ParseDuration(step)
+	if err != nil {
+		return 0, err
+	}
+	return int(d.Seconds()), nil
+}

--- a/server/internal/store/logstore/victoriametrics/queries.go
+++ b/server/internal/store/logstore/victoriametrics/queries.go
@@ -1,0 +1,450 @@
+/*
+SPDX-License-Identifier: GPL-3.0-or-later
+
+Copyright (C) 2025 Aaron Mathis aaron.mathis@gmail.com
+
+This file is part of GoSight.
+
+GoSight is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+GoSight is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GoBright. If not, see https://www.gnu.org/licenses/.
+*/
+
+// server/internal/store/victoriametrics.go
+
+package victoriametricstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aaronlmathis/gosight/shared/model"
+)
+
+// QueryInstant fetches the latest data points for a given metric with optional label filters.
+func (v *VictoriaStore) QueryInstant(metric string, filters map[string]string) ([]model.MetricRow, error) {
+	query := BuildPromQL(metric, filters)
+
+	fullURL := fmt.Sprintf("%s/api/v1/query?query=%s", v.url, url.QueryEscape(query))
+
+	resp, err := http.Get(fullURL)
+	if err != nil {
+		return nil, fmt.Errorf("VM instant query failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read failed: %w", err)
+	}
+
+	var parsed struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Metric map[string]string `json:"metric"`
+				Value  [2]interface{}    `json:"value"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("decode error: %w", err)
+	}
+	if parsed.Status != "success" {
+		return nil, fmt.Errorf("query failed: %s", parsed.Status)
+	}
+
+	var rows []model.MetricRow
+	for _, item := range parsed.Data.Result {
+		strVal, ok := item.Value[1].(string)
+		if !ok {
+			continue
+		}
+		val, err := strconv.ParseFloat(strVal, 64)
+		if err != nil {
+			continue
+		}
+		rows = append(rows, model.MetricRow{
+			Tags:  item.Metric,
+			Value: val,
+		})
+	}
+	return rows, nil
+}
+
+// QueryRange fetches time series data for a metric over a time range with optional label filters.
+func (v *VictoriaStore) QueryRange(metric string, start, end time.Time, step string, filters map[string]string) ([]model.Point, error) {
+	query := BuildPromQL(metric, filters)
+
+	params := url.Values{}
+	params.Set("query", query)
+	params.Set("start", start.Format(time.RFC3339))
+	params.Set("end", end.Format(time.RFC3339))
+	params.Set("step", step)
+
+	fullURL := fmt.Sprintf("%s/api/v1/query_range?%s", v.url, params.Encode())
+
+	resp, err := http.Get(fullURL)
+	if err != nil {
+		return nil, fmt.Errorf("VM range query failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read failed: %w", err)
+	}
+
+	var parsed struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Metric map[string]string `json:"metric"`
+				Values [][]interface{}   `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("decode error: %w", err)
+	}
+	if parsed.Status != "success" {
+		return nil, fmt.Errorf("query failed: %s", parsed.Status)
+	}
+
+	var points []model.Point
+	for _, series := range parsed.Data.Result {
+		for _, val := range series.Values {
+			tsRaw, ok1 := val[0].(float64)
+			valStr, ok2 := val[1].(string)
+			if !ok1 || !ok2 {
+				continue
+			}
+			valFloat, err := strconv.ParseFloat(valStr, 64)
+			if err != nil {
+				continue
+			}
+			points = append(points, model.Point{
+				Timestamp: time.Unix(int64(tsRaw), 0).UTC().Format(time.RFC3339),
+				Value:     valFloat,
+			})
+		}
+	}
+	return points, nil
+}
+
+func (v *VictoriaStore) GetAllKnownMetricNames() []string {
+	return v.cache.GetAllMetricNames()
+}
+
+func (v *VictoriaStore) QueryMultiInstant(metricNames []string, filters map[string]string) ([]model.MetricRow, error) {
+	//utils.Debug("Executing VictoriaStore.QueryMultiInstant")
+	if len(metricNames) == 0 {
+		// Default to all known metric names if available
+		metricNames = v.GetAllKnownMetricNames()
+		//utils.Debug("No metric names provided, using all known metric names: %v", metricNames)
+	}
+
+	var query string
+	if len(metricNames) == 1 {
+		// Single metric → clean style: metric{label="value"}
+		base := metricNames[0]
+		if len(filters) > 0 {
+			var parts []string
+			for k, v := range filters {
+				parts = append(parts, fmt.Sprintf(`%s="%s"`, k, v))
+			}
+			sort.Strings(parts)
+			query = fmt.Sprintf(`%s{%s}`, base, strings.Join(parts, ","))
+		} else {
+			query = base
+		}
+	} else {
+		// Multiple metrics → regex match on __name__
+		nameSelector := fmt.Sprintf(`__name__=~"%s"`, strings.Join(metricNames, "|"))
+		var parts []string
+		parts = append(parts, nameSelector)
+		for k, v := range filters {
+			parts = append(parts, fmt.Sprintf(`%s="%s"`, k, v))
+		}
+		sort.Strings(parts)
+		query = fmt.Sprintf("{%s}", strings.Join(parts, ","))
+	}
+
+	// Build full URL
+	reqURL := fmt.Sprintf("%s/api/v1/query?query=%s", v.url, url.QueryEscape(query))
+	//utils.Debug("QueryMultiInstant URL: %s", reqURL)
+	// Make HTTP request
+	resp, err := http.Get(reqURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("victoriametrics error: %s", string(body))
+	}
+
+	// Parse response
+	var vmResp struct {
+		Status string `json:"status"`
+		Data   struct {
+			Result []struct {
+				Metric map[string]string `json:"metric"`
+				Value  [2]interface{}    `json:"value"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&vmResp); err != nil {
+		return nil, err
+	}
+
+	// Convert to MetricRow
+	var rows []model.MetricRow
+	for _, item := range vmResp.Data.Result {
+		// Extract timestamp
+		tsFloat, ok := item.Value[0].(float64)
+		if !ok {
+			continue
+		}
+		timestamp := int64(tsFloat * 1000) // seconds → milliseconds
+
+		// Extract metric value
+		valStr, ok := item.Value[1].(string)
+		if !ok {
+			continue
+		}
+		val, err := strconv.ParseFloat(valStr, 64)
+		if err != nil {
+			continue
+		}
+
+		rows = append(rows, model.MetricRow{
+			Value:     val,
+			Tags:      item.Metric,
+			Timestamp: timestamp,
+		})
+	}
+
+	return rows, nil
+}
+
+func (v *VictoriaStore) QueryMultiRange(metrics []string, start, end time.Time, step string, filters map[string]string) ([]model.MetricRow, error) {
+	if len(metrics) == 0 {
+		return nil, nil
+	}
+	var query string
+	if len(metrics) == 1 {
+		// Single metric → clean form
+		base := metrics[0]
+		if len(filters) > 0 {
+			var parts []string
+			for k, v := range filters {
+				if k == "step" {
+					continue
+				}
+				parts = append(parts, fmt.Sprintf(`%s="%s"`, k, v))
+			}
+			sort.Strings(parts)
+			query = fmt.Sprintf(`%s{%s}`, base, strings.Join(parts, ","))
+		} else {
+			query = base
+		}
+	} else {
+		// Multi-metric → __name__=~ form
+		nameSelector := fmt.Sprintf(`__name__=~"%s"`, strings.Join(metrics, "|"))
+		var parts []string
+		parts = append(parts, nameSelector)
+		for k, v := range filters {
+			parts = append(parts, fmt.Sprintf(`%s="%s"`, k, v))
+		}
+		sort.Strings(parts)
+		query = fmt.Sprintf("{%s}", strings.Join(parts, ","))
+	}
+
+	// Build URL
+	params := url.Values{}
+	params.Set("query", query)
+	params.Set("start", start.Format(time.RFC3339))
+	params.Set("end", end.Format(time.RFC3339))
+
+	secs, err := parseDurationToSeconds(step)
+	if err != nil {
+		return nil, fmt.Errorf("invalid step: %v", err)
+	}
+	params.Set("step", strconv.Itoa(secs))
+
+	fullURL := fmt.Sprintf("%s/api/v1/query_range?%s", v.url, params.Encode())
+	//utils.Debug("QueryMultiRange URL: %s", fullURL)
+	resp, err := http.Get(fullURL)
+	if err != nil {
+		return nil, fmt.Errorf("VM QueryMultiRange failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read failed: %w", err)
+	}
+
+	var parsed struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Metric map[string]string `json:"metric"`
+				Values [][]interface{}   `json:"values"` // [ [timestamp, value], ... ]
+			} `json:"result"`
+		} `json:"data"`
+	}
+
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("decode error: %w", err)
+	}
+	if parsed.Status != "success" {
+		return nil, fmt.Errorf("query failed: %s", parsed.Status)
+	}
+
+	var rows []model.MetricRow
+	for _, series := range parsed.Data.Result {
+		for _, val := range series.Values {
+			tsRaw, ok1 := val[0].(float64)
+			valStr, ok2 := val[1].(string)
+			if !ok1 || !ok2 {
+				continue
+			}
+			valFloat, err := strconv.ParseFloat(valStr, 64)
+			if err != nil {
+				continue
+			}
+			rows = append(rows, model.MetricRow{
+				Timestamp: int64(tsRaw * 1000), // convert seconds → ms
+				Value:     valFloat,
+				Tags:      series.Metric,
+			})
+		}
+	}
+
+	return rows, nil
+}
+
+// FetchDimensionsForMetric queries VictoriaMetrics for a given metric and extracts dimension keys.
+func (v *VictoriaStore) FetchDimensionsForMetric(metric string) ([]string, error) {
+	queryURL := fmt.Sprintf("%s/api/v1/query?query=%s", v.url, url.QueryEscape(metric))
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(queryURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query VictoriaMetrics: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("VictoriaMetrics returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var parsed struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Metric map[string]string `json:"metric"`
+				Value  []interface{}     `json:"value"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to decode JSON: %w", err)
+	}
+
+	if parsed.Status != "success" {
+		return nil, fmt.Errorf("VictoriaMetrics query status not success: %s", parsed.Status)
+	}
+
+	// Collect unique dimension keys
+	dimSet := make(map[string]struct{})
+
+	for _, series := range parsed.Data.Result {
+		for key := range series.Metric {
+			if key == "__name__" {
+				continue // skip Prometheus internal field
+			}
+			dimSet[key] = struct{}{}
+		}
+	}
+
+	if len(dimSet) == 0 {
+		return nil, fmt.Errorf("no dimensions found for metric %s", metric)
+	}
+
+	var dims []string
+	for k := range dimSet {
+		dims = append(dims, k)
+	}
+
+	return dims, nil
+}
+
+func (v *VictoriaStore) ListLabelValues(label string, contains string) ([]string, error) {
+	queryURL := fmt.Sprintf("%s/api/v1/label/%s/values", v.url, url.PathEscape(label))
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(queryURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query VictoriaMetrics: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("victoria metrics returned %s", resp.Status)
+	}
+
+	var parsed struct {
+		Status string   `json:"status"`
+		Data   []string `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, err
+	}
+
+	if contains != "" {
+		contains = strings.ToLower(contains)
+		filtered := make([]string, 0, len(parsed.Data))
+		for _, val := range parsed.Data {
+			if strings.Contains(strings.ToLower(val), contains) {
+				filtered = append(filtered, val)
+			}
+		}
+		return filtered, nil
+	}
+
+	return parsed.Data, nil
+}

--- a/server/internal/store/logstore/victoriametrics/victoriametrics.go
+++ b/server/internal/store/logstore/victoriametrics/victoriametrics.go
@@ -1,0 +1,91 @@
+/*
+SPDX-License-Identifier: GPL-3.0-or-later
+
+Copyright (C) 2025 Aaron Mathis aaron.mathis@gmail.com
+
+This file is part of GoSight.
+
+GoSight is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+GoSight is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GoBright. If not, see https://www.gnu.org/licenses/.
+*/
+
+// server/internal/store/victoriametrics.go
+
+package victorialogstore
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/aaronlmathis/gosight/server/internal/cache"
+	"github.com/aaronlmathis/gosight/shared/model"
+)
+
+type VictoriaLogStore struct {
+	url    string
+	client *http.Client
+	cache  cache.MetricCache
+}
+
+// NewVictoriaStore
+func NewVictoriaLogStore(url string, logache cache.LogCache) (*VictoriaLogStore, error) {
+	return &VictoriaLogStore{
+		url:    url,
+		client: &http.Client{Timeout: 10 * time.Second},
+		cache:  metricCache,
+	}, nil
+}
+
+func (v *VictoriaStore) Write(batch []model.MetricPayload) error {
+	if len(batch) == 0 {
+		return nil
+	}
+
+	payload := buildPrometheusFormat(batch)
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, _ = gz.Write([]byte(payload))
+	_ = gz.Close()
+
+	req, err := http.NewRequest("POST", v.url+"/api/v1/import/prometheus", &buf)
+	if err != nil {
+		return fmt.Errorf("VM request build failed: %w", err)
+	}
+
+	req.Header.Set("Content-Encoding", "gzip")
+	req.Header.Set("Content-Type", "text/plain")
+
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("VM request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("VM response error: %s", string(body))
+	}
+
+	return nil
+}
+
+func (v *VictoriaStore) Close() error {
+	// No resources to release
+	// May Need in future
+	return nil
+}

--- a/shared/model/log.go
+++ b/shared/model/log.go
@@ -60,6 +60,12 @@ type LogPayload struct {
 	Meta       *Meta
 }
 
+type StoredLog struct {
+	LogID string   `json:"log_id"`
+	Log   LogEntry `json:"log"`
+	Meta  *Meta    `json:"meta,omitempty"` // from LogPayload
+}
+
 // LogFilter is used to filter logs based on various criteria.
 // It includes the limit of logs to return, the log levels to filter by,
 // the unit of the logs, the source of the logs, a string to search for in the logs,


### PR DESCRIPTION
Victoria Metrics + JSON File is now officially a logstore option for gosight. Log meta/labels are stored in time-series while message body is stored in a corresponding compressed JSON file. LogCache has been added as well to cache indexes between the two. log_id is stored in label of returned log entries to assist in finding message body.